### PR TITLE
Added minion metadata constructs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,21 @@ if err != nil {
 }
 return &master.Client{GofigureClient: pb.NewGofigureClient(conn)}, nil
 ```
+
+
+### Creating your certificates locally
+
+```bash
+mkdir myCerts
+cd myCerts
+openssl genrsa -des3 -out rootCA.key 4096
+openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.crt
+openssl genrsa -out mydomain.com.key 2048
+openssl req -new -sha256 -key mydomain.com.key -subj "/C=US/ST=CA/O=MyOrg, Inc./CN=mydomain.com" -out mydomain.com.csr 
+openssl x509 -req -in mydomain.com.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out mydomain.com.crt -days 500 -sha256
+```
+
+Then you can create your server
+```bash
+./gofigure serve --caFile myCerts/rootCA.crt --certFile=myCerts/mydomain.com.crt --keyFile=myCerts/mydomain.com.key --bind=0.0.0.0 --port=8000
+```

--- a/example.go
+++ b/example.go
@@ -112,7 +112,21 @@ func main() {
 			log.Fatal(err)
 		}
 	case "serve":
-		minion.Serve(*serveCAFile, *serveCertFile, *serveKeyFile, *serveBind, *servePort)
+
+		client, err := minion.ConstructMinion(nil,
+			nil,
+			minion.CreateGrpcServer(*serveCAFile, *serveCertFile, *serveKeyFile),
+			minion.SetBind(*serveBind),
+			minion.SetPort(*servePort),
+		)
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		client.StartServer()
+
+		// minion.Serve(*serveCAFile, *serveCertFile, *serveKeyFile, *serveBind, *servePort)
 	}
 }
 

--- a/minion/metadata.go
+++ b/minion/metadata.go
@@ -1,0 +1,133 @@
+package minion
+
+import (
+	"github.com/alexhunt7/gofigure/credentials"
+	"google.golang.org/grpc"
+	"net"
+	"sync"
+)
+
+// Minion implements the remote side of the gofigure service.
+// It also is a threadsafe struct holding all meta info
+type Minion struct {
+	Lock       *sync.Mutex
+	grpcServer *grpc.Server
+	Metadata   *MinionMetadata
+}
+
+type MinionMetadata struct {
+	CaFile   string
+	CertFile string
+	KeyFile  string
+	Bind     net.IP
+	Port     int
+}
+
+func (minion *MinionMetadata) Enumerate() {}
+
+// Constructs the minion right away if we have the grpcServer variable + metadata
+func ConstructMinion(lock *sync.Mutex, grpcServer *grpc.Server, optionalVars ...func(*Minion) error) (*Minion, error) {
+	obj := &Minion{
+		Lock:       lock,
+		grpcServer: grpcServer,
+		Metadata:   &MinionMetadata{},
+	}
+
+	// Create mutex lock if we're not passing in a lock already
+	if obj.Lock == nil {
+		obj.Lock = &sync.Mutex{}
+	}
+
+	// for any other optional options the user can pass into the constructor
+	for _, setVars := range optionalVars {
+		err := setVars(obj)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return obj, nil
+}
+
+func SetCaFile(caFile string) func(*Minion) error {
+	return func(minion *Minion) error {
+		if caFile != "" {
+			minion.Lock.Lock()
+			minion.Metadata.CaFile = caFile
+			minion.Lock.Unlock()
+		}
+		return nil
+	}
+}
+
+func SetCertFile(certFile string) func(*Minion) error {
+	return func(minion *Minion) error {
+		if certFile != "" {
+			minion.Lock.Lock()
+			minion.Metadata.CertFile = certFile
+			minion.Lock.Unlock()
+		}
+		return nil
+	}
+}
+func SetKeyFile(keyFile string) func(*Minion) error {
+	return func(minion *Minion) error {
+		if keyFile != "" {
+			minion.Lock.Lock()
+			minion.Metadata.KeyFile = keyFile
+			minion.Lock.Unlock()
+		}
+		return nil
+	}
+}
+func SetBind(bind net.IP) func(*Minion) error {
+	return func(minion *Minion) error {
+		if bind != nil {
+			minion.Lock.Lock()
+			minion.Metadata.Bind = bind
+			minion.Lock.Unlock()
+		}
+		return nil
+	}
+}
+func SetPort(port int) func(*Minion) error {
+	return func(minion *Minion) error {
+		if port != 0 {
+			minion.Lock.Lock()
+			minion.Metadata.Port = port
+			minion.Lock.Unlock()
+		}
+		return nil
+	}
+}
+
+// Function to set the entire object if the user passes in all metadata struct
+func CreateGrpcServer(caFile, certFile, keyFile string) func(*Minion) error {
+	return func(minion *Minion) error {
+		creds, err := credentials.Load(caFile, certFile, keyFile)
+		if err != nil {
+			return err
+		}
+
+		grpcServer := grpc.NewServer(grpc.Creds(creds))
+
+		minion.Lock.Lock()
+		minion.grpcServer = grpcServer
+		minion.Lock.Unlock()
+
+		minion.Lock.Lock()
+		minion.Metadata.CaFile = caFile
+		minion.Lock.Unlock()
+
+		minion.Lock.Lock()
+		minion.Metadata.KeyFile = keyFile
+		minion.Lock.Unlock()
+
+		minion.Lock.Lock()
+		minion.Metadata.CertFile = certFile
+		minion.Lock.Unlock()
+
+		return nil
+	}
+}

--- a/minion/metadata_test.go
+++ b/minion/metadata_test.go
@@ -1,0 +1,44 @@
+package minion
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"github.com/stretchr/testify/require"
+
+)
+
+
+func TestMetadata(t *testing.T) {
+	require := require.New(t)
+
+	caFile := "../testdata/ca-cert.pem"
+	certFile := "../testdata/cert.pem"
+	keyFile := "../testdata/key.pem"
+	bind := net.ParseIP("127.0.0.1")
+	port := 10001
+
+	testClient, err := ConstructMinion(nil,
+		nil,
+		CreateGrpcServer(caFile, certFile, keyFile),
+		SetBind(bind),
+		SetPort(port),
+	)
+	if testClient.Metadata.Port != port {
+		t.Fatal(fmt.Sprintf("%d != %d", port, testClient.Metadata.Port))
+	}
+
+	if testClient.Metadata.CertFile != certFile{
+		t.Fatal(fmt.Sprintf("%s != %s", certFile, testClient.Metadata.CertFile))
+	}
+
+	if testClient.Metadata.CaFile != caFile{
+		t.Fatal(fmt.Sprintf("%s != %s", caFile, testClient.Metadata.CaFile))
+	}
+
+	if testClient.Metadata.KeyFile != keyFile{
+		t.Fatal(fmt.Sprintf("%s != %s", keyFile, testClient.Metadata.KeyFile))
+	}
+
+	require.Nil(err)
+}


### PR DESCRIPTION
Added a constructor to create the minion object so we can just initialize it and set useful core or metadata variables to the client program, and just StartServer. It also makes constructing the minion thread safe if we were to create multiple go-routines that creates minion profiles.

I think this methodology of creating minions (and potentially masters) makes readability of the code a bit easier, safer, and we can extend the minion object to additional functions without passing in function parameters all the time. 

Verified testing constructor
```
[andrew@master minion]$ go test metadata.go metadata_test.go
ok      command-line-arguments  0.004s
```